### PR TITLE
[DF-82] testCheckTextInNewMessageWindow [Alerts,Frames&Windows/BrowserWindows]

### DIFF
--- a/src/test/java/pages/AlertsFramesWindows/BrowserWindowsPage.java
+++ b/src/test/java/pages/AlertsFramesWindows/BrowserWindowsPage.java
@@ -3,6 +3,7 @@ package pages.AlertsFramesWindows;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
+import org.openqa.selenium.support.ui.ExpectedConditions;
 
 public class BrowserWindowsPage extends AlertsFramesWindowsPage {
     @FindBy(xpath = "//button[@id='tabButton']")
@@ -14,25 +15,41 @@ public class BrowserWindowsPage extends AlertsFramesWindowsPage {
     @FindBy(xpath = "//button[@id='messageWindowButton']")
     private WebElement messageWindowButton;
 
+    @FindBy(xpath = "//body/")
+    private WebElement body;
+
     public BrowserWindowsPage(WebDriver driver) {
         super(driver);
     }
 
     public SamplePage clickNewTabButton() {
-        click(tabButton);
+        if(tabButton.isDisplayed() && tabButton.isEnabled()) {
+            click(tabButton);
+        }
 
         return new SamplePage(getDriver());
     }
 
-    public BrowserWindowsPage clickNewWindowButton() {
-        click(windowButton);
+    public SamplePage clickNewWindowButton() {
+        if(windowButton.isDisplayed() && windowButton.isEnabled()) {
+            click(windowButton);
+        }
+
+        return new SamplePage(getDriver());
+    }
+
+    public BrowserWindowsPage clickNewWindowMessageButton() {
+        if(messageWindowButton.isDisplayed() && messageWindowButton.isEnabled()) {
+            click(messageWindowButton);
+        }
 
         return new BrowserWindowsPage(getDriver());
     }
 
-    public BrowserWindowsPage clickNewWindowMessageButton() {
-        click(messageWindowButton);
+    public String getNewWindowMessageBodyText() {
+        getWait20().until(ExpectedConditions.numberOfWindowsToBe(2));
+        switchToAnotherWindow();
 
-        return new BrowserWindowsPage(getDriver());
+        return getText(body);
     }
 }

--- a/src/test/java/pages/AlertsFramesWindows/SamplePage.java
+++ b/src/test/java/pages/AlertsFramesWindows/SamplePage.java
@@ -12,6 +12,7 @@ public class SamplePage extends BrowserWindowsPage{
     public SamplePage(WebDriver driver) {
         super(driver);
     }
+
     public String getH1TextFromNewWindow() {
         switchToAnotherWindow();
 

--- a/src/test/java/pages/BasePage.java
+++ b/src/test/java/pages/BasePage.java
@@ -376,4 +376,10 @@ public abstract class BasePage {
         Alert alert = getDriver().switchTo().alert();
         alert.accept();
     }
+
+    public String getTextFromAlert() {
+        getWait20().until(ExpectedConditions.alertIsPresent());
+
+        return getDriver().switchTo().alert().getText();
+    }
 }

--- a/src/test/java/tests/AlertsFramesWindowTest/BrowserWindowsTest.java
+++ b/src/test/java/tests/AlertsFramesWindowTest/BrowserWindowsTest.java
@@ -2,6 +2,7 @@ package tests.AlertsFramesWindowTest;
 
 import base.BaseTest;
 import org.testng.Assert;
+import org.testng.annotations.Ignore;
 import org.testng.annotations.Test;
 
 public class BrowserWindowsTest extends BaseTest {
@@ -9,8 +10,8 @@ public class BrowserWindowsTest extends BaseTest {
     @Test
     public void testCheckH1TextAndURLInNewTab() {
         final String expectedURLFirstWindow = "https://demoqa.com/browser-windows";
-        final String expectedH1HeaderNewWindow = "This is a sample page";
-        final String expectedURLNewWindow = "https://demoqa.com/sample";
+        final String expectedH1HeaderNewTab = "This is a sample page";
+        final String expectedURLNewTab = "https://demoqa.com/sample";
 
         openBaseURL()
                 .clickAlertsFramesWindowsMenu()
@@ -22,13 +23,58 @@ public class BrowserWindowsTest extends BaseTest {
                 .clickNewTabButton()
                 .getH1TextFromNewWindow();
 
-        String actualURLNewWindow = getSamplePage().getCurrentURL();
+        String actualURLNewTab = getSamplePage().getCurrentURL();
 
-        String actualURLPreviousPage = getSamplePage().moveToPreviousPage().getCurrentURL();
+        String actualURLPreviousWindow = getSamplePage().moveToPreviousPage().getCurrentURL();
+
+        Assert.assertNotEquals(actualURLNewTab, expectedURLFirstWindow);
+        Assert.assertEquals(actualURLNewTab, expectedURLNewTab);
+        Assert.assertEquals(actualH1HeaderNewWindow, expectedH1HeaderNewTab);
+        Assert.assertEquals(actualURLPreviousWindow, expectedURLFirstWindow);
+    }
+
+    @Test
+    public void testCheckH1TextAndURLInNewWindow() {
+        final String expectedURLFirstWindow = "https://demoqa.com/browser-windows";
+        final String expectedH1HeaderNewWindow = "This is a sample page";
+        final String expectedURLNewWindow = "https://demoqa.com/sample";
+
+    openBaseURL()
+                .clickAlertsFramesWindowsMenu()
+                .selectBrowserWindowsSubMenu();
+
+    String actualURLFirstWindow = getBrowserWindowsPage().getCurrentURL();
+
+    String actualH1HeaderNewWindow =  getBrowserWindowsPage()
+            .clickNewWindowButton()
+            .getH1TextFromNewWindow();
+
+    String actualURLNewWindow = getSamplePage()
+            .getCurrentURL();
+
+    String actualURLPreviousWindow = getSamplePage()
+            .moveToPreviousPage()
+            .getCurrentURL();
 
         Assert.assertNotEquals(actualURLNewWindow, expectedURLFirstWindow);
         Assert.assertEquals(actualURLNewWindow, expectedURLNewWindow);
         Assert.assertEquals(actualH1HeaderNewWindow, expectedH1HeaderNewWindow);
-        Assert.assertEquals(actualURLPreviousPage, expectedURLFirstWindow);
+        Assert.assertEquals(actualURLPreviousWindow, expectedURLFirstWindow);
+}
+
+    //подивіться цей тест, будь-ласка. Фаєрфокс відкриває вікно нормально, а Хром не показує url
+    @Ignore
+    @Test
+    public void testCheckTextInNewWindowMessage() {
+        final String expectedTextNewWindowMessage = "Knowledge increases by sharing but not by saving. " +
+                "Please share this website with your friends and in your organization.";
+
+        String actualTextNewWindowMessage = openBaseURL()
+                .clickAlertsFramesWindowsMenu()
+                .selectBrowserWindowsSubMenu()
+                .clickNewWindowMessageButton()
+                .getNewWindowMessageBodyText();
+
+        Assert.assertEquals(actualTextNewWindowMessage, expectedTextNewWindowMessage);
     }
 }


### PR DESCRIPTION
RF + testCheckH1AndURLNewWindow is added

Need your help, guys.
Please, check ignored test in AlertsFramesWindowsTest/BrowserTest. 
The "New Window Message" button in Browser sub-menu opens differently from others.
Try it locally, pls.