### PR TITLE
added slf4j Logger

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,5 +47,11 @@
             <scope>test</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>1.7.30</version>
+        </dependency>
+
     </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,14 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-            <version>1.7.30</version>
+            <version>2.0.6</version>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/org.slf4j/slf4j-api -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>2.0.6</version>
         </dependency>
 
     </dependencies>

--- a/src/test/java/tests/ElementsTests/CheckBoxTest.java
+++ b/src/test/java/tests/ElementsTests/CheckBoxTest.java
@@ -13,7 +13,7 @@ import java.util.List;
 
 public class CheckBoxTest extends BaseTest {
 
-    @Test
+    @Test(retryAnalyzer = Retry.class)
     public void testAllCheckBoxSelected() {
         CheckBoxPage checkBoxPage = openBaseURL()
                 .clickElementsMenu()

--- a/src/test/java/tests/ElementsTests/CheckBoxTest.java
+++ b/src/test/java/tests/ElementsTests/CheckBoxTest.java
@@ -13,7 +13,7 @@ import java.util.List;
 
 public class CheckBoxTest extends BaseTest {
 
-    @Test(retryAnalyzer = Retry.class)
+    @Test
     public void testAllCheckBoxSelected() {
         CheckBoxPage checkBoxPage = openBaseURL()
                 .clickElementsMenu()

--- a/src/test/java/tests/ElementsTests/WebTablesTest.java
+++ b/src/test/java/tests/ElementsTests/WebTablesTest.java
@@ -1,12 +1,16 @@
 package tests.ElementsTests;
 
 import base.BaseTest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.testng.Assert;
 import org.testng.Reporter;
 import org.testng.annotations.Test;
 import pages.Elements.WebTablesPage;
 
 public class WebTablesTest extends BaseTest {
+
+    Logger logger = LoggerFactory.getLogger(WebTablesTest.class);
 
     @Test(priority = 1)
     public void test_CheckSearchBarWithValidData() {
@@ -18,6 +22,8 @@ public class WebTablesTest extends BaseTest {
                 .openWebTablesPage()
                 .inputFirstNameIntoSearchField(firstName)
                 .getTextFirstColumnRow();
+
+        logger.info("Actual First Name = " + actualFirstName);
 
         Assert.assertEquals(actualFirstName,expectedFirstName);
     }
@@ -88,7 +94,7 @@ public class WebTablesTest extends BaseTest {
                 .openWebTablesPage()
                 .addNew7UsersWithEmail();
 
-        Reporter.log("Result = " + webTablesPage.getAmountOfEmailsInTheTable(), true);
+        logger.info("Emails presented = " + webTablesPage.getAmountOfEmailsInTheTable());
 
         Assert.assertFalse(getWebTablesPage().isAnyEmailEmpty());
         Assert.assertEquals(webTablesPage.getAmountOfEmailsInTheTable(),expectedUsersPresented);

--- a/src/test/java/tests/ElementsTests/WebTablesTest.java
+++ b/src/test/java/tests/ElementsTests/WebTablesTest.java
@@ -1,12 +1,14 @@
 package tests.ElementsTests;
 
 import base.BaseTest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.testng.Assert;
-import org.testng.Reporter;
 import org.testng.annotations.Test;
 import pages.Elements.WebTablesPage;
 
 public class WebTablesTest extends BaseTest {
+    Logger logger = LoggerFactory.getLogger(WebTablesTest.class);
 
     @Test(priority = 1)
     public void test_CheckSearchBarWithValidData() {
@@ -18,6 +20,8 @@ public class WebTablesTest extends BaseTest {
                 .openWebTablesPage()
                 .inputFirstNameIntoSearchField(firstName)
                 .getTextFirstColumnRow();
+
+        logger.info("Actual First Name = " + actualFirstName);
 
         Assert.assertEquals(actualFirstName,expectedFirstName);
     }
@@ -88,7 +92,7 @@ public class WebTablesTest extends BaseTest {
                 .openWebTablesPage()
                 .addNew7UsersWithEmail();
 
-        Reporter.log("Result = " + webTablesPage.getAmountOfEmailsInTheTable(), true);
+        logger.info("Emails presented = " + webTablesPage.getAmountOfEmailsInTheTable());
 
         Assert.assertFalse(getWebTablesPage().isAnyEmailEmpty());
         Assert.assertEquals(webTablesPage.getAmountOfEmailsInTheTable(),expectedUsersPresented);


### PR DESCRIPTION
Resolve this issue with Logger

Failed to load class org.slf4j.impl.StaticLoggerBinder
This warning message is reported when the org.slf4j.impl.StaticLoggerBinder class could not be loaded into memory. This happens when no appropriate SLF4J binding could be found on the class path. Placing one (and only one) of slf4j-nop.jar slf4j-simple.jar, slf4j-log4j12.jar, slf4j-jdk14.jar or logback-classic.jar on the class path should solve the problem.

Note that slf4j-api versions 2.0.x and later use the [ServiceLoader](https://docs.oracle.com/javase/8/docs/api/java/util/ServiceLoader.html) mechanism. Backends such as logback 1.3 and later which target slf4j-api 2.x, do not ship with org.slf4j.impl.StaticLoggerBinder. If you place a logging backend which targets slf4j-api 2.0.x, you need slf4j-api-2.x.jar on the classpath. See also [relevant faq](https://www.slf4j.org/faq.html#changesInVersion18) entry.

SINCE 1.6.0 As of SLF4J version 1.6, in the absence of a binding, SLF4J will default to a no-operation (NOP) logger implementation.

If you are responsible for packaging an application and do not care about logging, then placing slf4j-nop.jar on the class path of your application will get rid of this warning message. Note that embedded components such as libraries or frameworks should not declare a dependency on any SLF4J binding but only depend on slf4j-api. When a library declares a compile-time dependency on a SLF4J binding, it imposes that binding on the end-user, thus negating SLF4J's purpose.